### PR TITLE
adding centos_7.5 with docker 1.13.1

### DIFF
--- a/scripts/centos/7.5.sh
+++ b/scripts/centos/7.5.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+sudo setenforce 0 && \
+sudo sed -i --follow-symlinks 's/^SELINUX=.*/SELINUX=disabled/g' /etc/sysconfig/selinux
+sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
+[dockerrepo]
+name=Docker Repository
+baseurl=https://yum.dockerproject.org/repo/main/centos/7
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.dockerproject.org/gpg
+EOF
+
+sudo mkdir -p /etc/systemd/system/docker.service.d
+sudo tee /etc/systemd/system/docker.service.d/override.conf <<- EOF
+[Service]
+ExecStart=
+ExecStart=/usr/bin/dockerd
+EOF
+
+sudo yum install -y yum-utils \
+    device-mapper-persistent-data \
+    lvm2
+
+sudo yum-config-manager \
+    --add-repo \
+    https://download.docker.com/linux/centos/docker-ce.repo
+
+sudo yum makecache fast
+sudo yum install -y http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.42-1.gitad8f0f7.el7.noarch.rpm
+sudo yum install -y http://mirror.centos.org/centos/7/extras/x86_64/Packages/pigz-2.3.3-1.el7.centos.x86_64.rpm
+
+#Installing RH's fork of docker 1.13.1
+sudo yum install -y docker-1.13.1
+sudo ln -s /usr/libexec/docker/docker-runc-current /usr/libexec/docker/docker-runc
+sudo ln -s ../../usr/libexec/docker/docker-proxy-current /usr/bin/docker-proxy
+
+sudo systemctl start docker
+sudo systemctl enable docker
+
+sudo yum install -y wget
+sudo yum install -y git
+sudo yum install -y unzip
+sudo yum install -y curl
+sudo yum install -y xz
+sudo yum install -y ipset
+sudo yum install -y bind-utils
+sudo yum install -y ntp
+sudo systemctl enable ntpd
+sudo systemctl start ntpd
+sudo getent group nogroup || sudo groupadd nogroup
+sudo getent group docker || sudo groupadd docker

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,7 @@ variable "os_image_version" {
   default = {
     "centos_7.2"      = ["centos-cloud", "centos-7-v20170523"]
     "centos_7.3"      = ["centos-cloud", "centos-7-v20170719"]
+    "centos_7.5"      = ["centos-cloud", "centos-7-v20181011"]
     "coreos_stable"   = ["coreos-cloud", "coreos-stable"]
     "coreos_1576.5.0" = ["coreos-cloud", "coreos-stable-1576-5-0-v20180105"]
     "coreos_1855.5.0" = ["coreos-cloud", "coreos-stable-1855-5-0-v20181024"]


### PR DESCRIPTION
We need to update the CentOS version to 7.5 that is using the RHEL version of docker according to DC/OS specifications. 

Docker 1.13.1 will be included in this version of CentOS 7.5. 

See below:
https://docs.mesosphere.com/version-policy/

https://jira.mesosphere.com/browse/DCOS-44386