### PR TITLE
main: including/updating 7.5 in tested oses module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ locals {
   os_version = "${element(split("_", var.os),1)}"
 
   os_special_version_script = {
-    centos = ["7.3"]
+    centos = ["7.3", "7.5"]
     coreos = []
     rhel   = []
   }

--- a/scripts/centos/7.5.sh
+++ b/scripts/centos/7.5.sh
@@ -46,6 +46,7 @@ sudo yum install -y xz
 sudo yum install -y ipset
 sudo yum install -y bind-utils
 sudo yum install -y ntp
+sudo yum remove -y yum-cron
 sudo systemctl enable ntpd
 sudo systemctl start ntpd
 sudo getent group nogroup || sudo groupadd nogroup


### PR DESCRIPTION
This PR adds 7.5 within the main.tf of the module to let it know that Centos 7.5 is included and called. The behavior without this change will default to the Centos 7.3 instructions.